### PR TITLE
Enable passing username on share creation

### DIFF
--- a/Hauk/Models/SharingManager.swift
+++ b/Hauk/Models/SharingManager.swift
@@ -124,6 +124,7 @@ final class SharingManager: ObservableObject, @unchecked Sendable {
         let preferredLinkId = UserDefaults.standard.string(forKey: "preferredLinkId") ?? ""
 //        let isPasswordProtected = UserDefaults.standard.bool(forKey: "isPasswordProtected")
 //        let sharePassword = UserDefaults.standard.string(forKey: "sharePassword") ?? ""
+        let username = UserDefaults.standard.string(forKey: "username") ?? ""
         let password = UserDefaults.standard.string(forKey: "password") ?? ""
         
         // Use default value of 1 if not set
@@ -134,6 +135,7 @@ final class SharingManager: ObservableObject, @unchecked Sendable {
             ("mod", "0"),
             ("lid", preferredLinkId),
             ("e2e", "0"),
+            ("usr", username),
             ("pwd", password),
             ("ado", "0"),
             ("int", "\(interval)")

--- a/Hauk/Views/SettingsView.swift
+++ b/Hauk/Views/SettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @AppStorage("serverUrl") private var serverUrl = ""
-//    @AppStorage("username") private var username = ""
+    @AppStorage("username") private var username = ""
     @AppStorage("password") private var password = ""
     @AppStorage("preferredLinkId") private var preferredLinkId = ""
     @AppStorage("updateInterval") private var updateInterval = 1
@@ -18,10 +18,10 @@ struct SettingsView: View {
                     .disableAutocorrection(true)
                     .keyboardType(.URL)
                 
-//                TextField("Username (optional)", text: $username)
-//                    .autocapitalization(.none)
-//                    .disableAutocorrection(true)
-//                
+                TextField("Username (optional)", text: $username)
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+
                 SecureField("Password (optional)", text: $password)
             }
             


### PR DESCRIPTION
As far as I can tell, this should allow setting a username to work with HTPASSWD or LDAP auth.  Unfortunately I'm unable to test it so this is as much as I can do to help.

Thanks for creating this client app!  I've been looking forward to trying it on a family member's device and was stymied by the lack of username support.  Hopefully this PR is helpful to you in getting that added :)
