### PR TITLE
Enable allowing link to be adopted

### DIFF
--- a/Hauk/Models/SharingManager.swift
+++ b/Hauk/Models/SharingManager.swift
@@ -122,6 +122,8 @@ final class SharingManager: ObservableObject, @unchecked Sendable {
         
         // Get settings
         let preferredLinkId = UserDefaults.standard.string(forKey: "preferredLinkId") ?? ""
+        // Boolean, but the API wants it as an int.  Default to the more private false
+        let isAdoptable = UserDefaults.standard.object(forKey: "isAdoptable") as? Int ?? 0
 //        let isPasswordProtected = UserDefaults.standard.bool(forKey: "isPasswordProtected")
 //        let sharePassword = UserDefaults.standard.string(forKey: "sharePassword") ?? ""
         let password = UserDefaults.standard.string(forKey: "password") ?? ""
@@ -135,7 +137,7 @@ final class SharingManager: ObservableObject, @unchecked Sendable {
             ("lid", preferredLinkId),
             ("e2e", "0"),
             ("pwd", password),
-            ("ado", "0"),
+            ("ado", "\(isAdoptable)"),
             ("int", "\(interval)")
         ]
         

--- a/Hauk/Views/SettingsView.swift
+++ b/Hauk/Views/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @AppStorage("password") private var password = ""
     @AppStorage("preferredLinkId") private var preferredLinkId = ""
     @AppStorage("updateInterval") private var updateInterval = 1
+    @AppStorage("isAdoptable") private var isAdoptable = true
 //    @AppStorage("isPasswordProtected") private var isPasswordProtected = false
 //    @AppStorage("sharePassword") private var sharePassword = ""
     @EnvironmentObject var locationManager: LocationManager
@@ -35,6 +36,8 @@ struct SettingsView: View {
                         in: 1...60)
                     .help("Minimum interval is 1 second")
                 
+                Toggle("Allow link adoption?", isOn: $isAdoptable)
+
 //                Toggle("Password Protected Shares", isOn: $isPasswordProtected)
                 
 //                if isPasswordProtected {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The app currently lacks some features the original Android app has, mainly
 
 - [ ] Password protected shares
 - [ ] Creating a group
-- [ ] Participating in a group
+- [ ] Joining a group
+- [x] Participating in a group via link adoption
 - [x] Set sharing duration from Shortcut action 
 
 Please do open PRs for this!


### PR DESCRIPTION
If I understand things correctly, this is meant to allow the user to choose whether their link can be adopted into a group by another user.

As with PR #2 I am unable to actually build or test this locally, so I'm just hoping it's about right and gives you something to build on.  This one is just a nice-to-have rather than blocking my ability to make use of the app, though :)
