### PR TITLE
Fix location status text for when-in-use authorization

### DIFF
--- a/Hauk/Views/SettingsView.swift
+++ b/Hauk/Views/SettingsView.swift
@@ -77,7 +77,7 @@ struct SettingsView: View {
     private var locationStatusText: String {
         switch locationManager.authorizationStatus {
         case .authorizedAlways: return "Always"
-        case .authorizedWhenInUse: return "While Using (for a better experience: Change to 'Always' in System Settings"
+        case .authorizedWhenInUse: return "While Using (for a better experience: change to 'Always' in System Settings)"
         case .denied: return "Denied. Hauk cannot share your location."
         case .restricted: return "Restricted. Hauk cannot share your location"
         case .notDetermined: return "Not Determined"


### PR DESCRIPTION
## Summary
- close parenthesis in authorizedWhenInUse status string in `SettingsView`
- tweak text to instruct to change to Always in System Settings

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d5009f74832681da929ec0f6df2d